### PR TITLE
Datetime2 append hotfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RtoSQLServer
 Title: Load R Dataframes into SQL Server Database Tables
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: c(
     person("Tom", "Wilson", email = "thomas.wilson@gov.scot", role = "cre"),
     person("Miles", "Drake", email = "miles.drake@gov.scot", role = "aut"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,10 +52,13 @@ r_to_sql_character_sizes <- function(max_string) {
 
 df_to_metadata <- function(dataframe) {
   col_types <- sapply(dataframe, r_to_sql_data_type)
-  data.frame(
+  df <- data.frame(
     column_name = names(col_types), data_type = unname(col_types),
     stringsAsFactors = FALSE
   )
+  # db_table_metdata stored procedure does not specify size of datetime2 cols
+  df[df$data_type == "datetime2(3)", "data_type"] <- "datetime2"
+  df
 }
 
 


### PR DESCRIPTION
Bug fix. `df_metadata` mapping cols to datetime2(3) but no size specified in stored procedure ran by `db_table_metadata`.